### PR TITLE
Normalize path for Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ module.exports.fmImagesToRelative = node => {
         const foundImageNode = _.find(fileNodes, file => {
           if (!file.dir) return;
           imagePath = path.join(file.dir, '..', value);
-          return file.absolutePath === imagePath;
+          return path.normalize(file.absolutePath) === imagePath;
         });
         if (foundImageNode) {
           return path.relative(


### PR DESCRIPTION
On my Windows machine, `file.absolutePath` and `imagePath`  were not matching because the former had forward slashes and the later backward slashes. This might fix #2.

Thanks a lot for this awesome plugin, by the way; this issue was a real blocker for me! I hope the Gatsby team comes up with a solution soon.