### PR TITLE
Update lodash to solve moderate security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cheerio": "1.0.0-rc.2",
     "deep-map": "1.5.0",
     "is-relative-url": "2.0.0",
-    "lodash": "4.17.5",
+    "lodash": "4.17.11",
     "slash": "2.0.0",
     "unist-util-select": "1.5.0"
   },


### PR DESCRIPTION
The audit report executed with `npm audit` says:

```                                       
  Moderate        Prototype Pollution                   
  Package         lodash                                         
  Patched in      >=4.17.11                                      
  Dependency of   gatsby-remark-relative-images
  Path            gatsby-remark-relative-images > lodash  
  More info       https://npmjs.com/advisories/782         
```

