### PR TITLE
Improve matching algorithm for markdown images

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,123 +12,124 @@ const polyfill = require(`babel-polyfill`);
 // 2. Convert the image src to be relative to its parent node
 // This will allow gatsby-remark-images to resolve the image correctly
 module.exports = ({ files, markdownNode, markdownAST, pathPrefix, getNode, reporter }, pluginOptions) => {
-	const defaults = {};
+  const defaults = {};
 
-	const options = _.defaults(pluginOptions, defaults);
+  const options = _.defaults(pluginOptions, defaults);
 
-	// This will only work for markdown syntax image tags
-	const markdownImageNodes = select(markdownAST, `image`);
+  // This will only work for markdown syntax image tags
+  const markdownImageNodes = select(markdownAST, `image`);
 
-	// This will also allow the use of html image tags
-	const rawHtmlNodes = select(markdownAST, `html`);
+  // This will also allow the use of html image tags
+  const rawHtmlNodes = select(markdownAST, `html`);
 
-	// Promise markdown images in body
-	Promise.all(
-		// Simple because there is no nesting in markdown
-		markdownImageNodes.map(
-			node =>
-				new Promise(async (resolve, reject) => {
-					// Only handle relative (local) urls
-					if (!isRelativeUrl(node.url)) {
-						return resolve();
-					}
-					// Get the markdown file's parent directory
-					const parentDirectory = getNode(markdownNode.parent).dir;
-					const imagePath = slash(path.join(parentDirectory, node.url))
-					// See if there is a matching file path from gatsby-source-filesystem
-					const imageNode = _.find(files, file => {
-						return slash(path.normalize(file.absolutePath)) === imagePath;
-					});
-					// Return if we didn't find a match
-					if (!imageNode) return resolve();
-					// Make the image src relative to the markdown file
-					node.url = slash(path.relative(parentDirectory, imagePath));
-					// Return modified node
-					return resolve(node);
-				})
-		)
-	).then(markdownImageNodes =>
-		// Process HTML images in markdown body
-		Promise.all(
-			// Complex because HTML nodes can contain multiple images
-			rawHtmlNodes.map(
-				node =>
-					new Promise(async (resolve, reject) => {
-						if (!node.value) {
-							return resolve();
-						}
+  // Promise markdown images in body
+  Promise.all(
+    // Simple because there is no nesting in markdown
+    markdownImageNodes.map(
+      node =>
+        new Promise(async (resolve, reject) => {
+          // Only handle relative (local) urls
+          if (!isRelativeUrl(node.url)) {
+            return resolve();
+          }
+          // Get the markdown file's parent directory
+          const parentDirectory = getNode(markdownNode.parent).dir;
+          // See if there is a matching file path from gatsby-source-filesystem
+          const imageNode = _.find(files, file => {
+            return slash(path.normalize(file.absolutePath)).endsWith(node.url);
+          });
+          // Return if we didn't find a match
+          if (!imageNode) return resolve();
+          // Make the image src relative to the markdown file
+          node.url = slash(
+            path.relative(parentDirectory, imageNode.absolutePath)
+          );
+          // Return modified node
+          return resolve(node);
+        })
+    )
+  ).then(markdownImageNodes =>
+    // Process HTML images in markdown body
+    Promise.all(
+      // Complex because HTML nodes can contain multiple images
+      rawHtmlNodes.map(
+        node =>
+          new Promise(async (resolve, reject) => {
+            if (!node.value) {
+              return resolve();
+            }
 
-						const $ = cheerio.load(node.value);
+            const $ = cheerio.load(node.value);
 
-						if ($(`img`).length === 0) {
-							// No img tags
-							return resolve();
-						}
+            if ($(`img`).length === 0) {
+              // No img tags
+              return resolve();
+            }
 
-						let imageRefs = [];
-						$(`img`).each(function() {
-							imageRefs.push($(this));
-						});
+            let imageRefs = [];
+            $(`img`).each(function() {
+              imageRefs.push($(this));
+            });
 
-						for (let thisImg of imageRefs) {
-							// Get the details we need.
-							let formattedImgTag = {};
-							formattedImgTag.url = thisImg.attr(`src`);
+            for (let thisImg of imageRefs) {
+              // Get the details we need.
+              let formattedImgTag = {};
+              formattedImgTag.url = thisImg.attr(`src`);
 
-							if (!formattedImgTag.url) {
-								return resolve();
-							}
-							// Only handle relative (local) urls
-							if (!isRelativeUrl(formattedImgTag.url)) {
-								return resolve();
-							}
+              if (!formattedImgTag.url) {
+                return resolve();
+              }
+              // Only handle relative (local) urls
+              if (!isRelativeUrl(formattedImgTag.url)) {
+                return resolve();
+              }
 
-							let imagePath;
-							const imageNode = _.find(files, file => {
-								if (file.sourceInstanceName === options.name) {
+              let imagePath;
+              const imageNode = _.find(files, file => {
+                if (file.sourceInstanceName === options.name) {
 									imagePath = path.join(file.dir, path.basename(formattedImgTag.url));
 									return slash(path.normalize(file.absolutePath)) === slash(imagePath);
-								}
-							});
+                }
+              });
 
-							if (!imageNode) return resolve();
+              if (!imageNode) return resolve();
 
-							const parentNode = getNode(markdownNode.parent);
-							// Make the image src relative to its parent node
+              const parentNode = getNode(markdownNode.parent);
+              // Make the image src relative to its parent node
 							thisImg.attr("src", slash(path.relative(parentNode.dir, imagePath)));
 
-							node.value = $(`body`).html(); // fix for cheerio v1
-						}
-						return resolve(node);
-					})
-			)
-		).then(htmlImageNodes => markdownImageNodes.concat(htmlImageNodes).filter(node => !!node))
-	);
+              node.value = $(`body`).html(); // fix for cheerio v1
+            }
+            return resolve(node);
+          })
+      )
+			).then(htmlImageNodes => markdownImageNodes.concat(htmlImageNodes).filter(node => !!node))
+  );
 };
 
 const fileNodes = [];
 
 module.exports.fmImagesToRelative = node => {
-	// Save file references
-	fileNodes.push(node);
-	// Only process markdown files
-	if (node.internal.type === `MarkdownRemark` || node.internal.type === `Mdx`) {
-		// Convert paths in frontmatter to relative
-		function makeRelative(value) {
-			if (_.isString(value) && path.isAbsolute(value)) {
-				let imagePath;
-				const foundImageNode = _.find(fileNodes, file => {
-					if (!file.dir) return;
-					imagePath = path.join(file.dir, path.basename(value));
-					return slash(path.normalize(file.absolutePath)) === slash(imagePath);
-				});
-				if (foundImageNode) {
+  // Save file references
+  fileNodes.push(node);
+  // Only process markdown files
+  if (node.internal.type === `MarkdownRemark` || node.internal.type === `Mdx`) {
+    // Convert paths in frontmatter to relative
+    function makeRelative(value) {
+      if (_.isString(value) && path.isAbsolute(value)) {
+        let imagePath;
+        const foundImageNode = _.find(fileNodes, file => {
+          if (!file.dir) return;
+          imagePath = path.join(file.dir, path.basename(value));
+          return slash(path.normalize(file.absolutePath)) === slash(imagePath);
+        });
+        if (foundImageNode) {
 					return slash(path.relative(path.join(node.fileAbsolutePath, ".."), imagePath));
-				}
-			}
-			return value;
-		}
-		// Deeply iterate through frontmatter data for absolute paths
-		deepMap(node.frontmatter, makeRelative, { inPlace: true });
-	}
+        }
+      }
+      return value;
+    }
+    // Deeply iterate through frontmatter data for absolute paths
+    deepMap(node.frontmatter, makeRelative, { inPlace: true });
+  }
 };


### PR DESCRIPTION
Closes #29 
Hi, this PR fixes what I explained in #29.
Basically I'm scanning through files (from gatsby-source-filesystem) and looking for the desired image only by its name, instead of absolute path, which was based on parent's directory.

- Before
```
// 'root/content/blog/images/my-image.jpg' === 'root/static/images/images/my-image.jpg'
// this will always result to false
const imageNode = _.find(files, file => {
   return slash(path.normalize(file.absolutePath)) === imagePath;
});
```
- After
```
// 'root/content/blog/images/my-image.jpg'.endsWith('images/my-image.jpg')
// this seems fine for me
const imageNode = _.find(files, file => {
   return slash(path.normalize(file.absolutePath)).endsWith(node.url);
});
```