### PR TITLE
feature: add support for explicity specifying the frontmatter fields to transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ exports.onCreateNode = ({ node }) => {
 };
 ```
 
+This syntax will convert all of your frontmatter fields. If you want to only transform specific fields, the method accepts an explicit list of fields to transform:
+
+```js
+// gatsby-node.js
+const { fmImagesToRelative } = require('gatsby-remark-relative-images');
+
+exports.onCreateNode = ({ node }) => {
+  fmImagesToRelative(node, ['image']);
+};
+```
+
+Note that the field names in that list will apply to any nested fields. There is currently no way to differentiate between, for example, `image` and `details.image`, the transform list will allow both fields.
+
 ## FAQs
 
 ### I'm getting the error: Field "image" must not have a selection since type "String" has no subfields

--- a/src/index.js
+++ b/src/index.js
@@ -108,13 +108,17 @@ module.exports = ({ files, markdownNode, markdownAST, pathPrefix, getNode, repor
 
 const fileNodes = [];
 
-module.exports.fmImagesToRelative = node => {
+module.exports.fmImagesToRelative = (node, fieldsToTransform) => {
+	const shouldSelectivelyTransform = Array.isArray(fieldsToTransform);
 	// Save file references
 	fileNodes.push(node);
 	// Only process markdown files
 	if (node.internal.type === `MarkdownRemark` || node.internal.type === `Mdx`) {
 		// Convert paths in frontmatter to relative
-		function makeRelative(value) {
+		function makeRelative(value, key) {
+			if (shouldSelectivelyTransform && fieldsToTransform.indexOf(key) === -1) {
+				return value
+			}
 			if (_.isString(value) && path.isAbsolute(value)) {
 				let imagePath;
 				const foundImageNode = _.find(fileNodes, file => {


### PR DESCRIPTION
This PR basically fixes #18 by introducing an optional whitelist.

API compatibility is assured by not changing the default behaviour, but by introducing an optional array of whitelisted fields.
It's still hard to track bugs introduced by this method, so if you're willing to make a breaking change, you might want to make the whitelist mandatory.

One limitation of this whitelist is that you cannot whitelist paths, only fieldnames. That means that any nested field will also be matched.
For example, if you take the following:  

```
---
image: /img.jpg
title: "my post"
footer: {
  image: /footer.jpg
}
---
```
and whitelist `["image"]`, both `image` and `footer.image` will be whitelisted, and there is no way to prevent this. I don't think it's gonna be that problematic.

I have tested this in production.