### PR TITLE
allow processing of custom markdown nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ module.exports = {
               // [Optional] Exclude the following fields, use dot notation for nested fields
               // No fields are excluded by default
               exclude: ['featured.skip'],
+              // [Optional] in case you want to process markdown nodes that were not created from a file
+              // you can provide a resolver function which produces the absolute path for a given node.
+              // In the example below the remarkNode was a child node of a fileNode. E.g. if you have
+              // markdown content in your frontmatter fields.
+              resolveNodePath: ({ node, getNode }) => {
+                let fileAbsolutePath = undefined;
+                let curNode = node;
+                while (curNode.parent && !fileAbsolutePath) {
+                  curNode = getNode(curNode.parent);
+                  fileAbsolutePath =
+                    curNode.fileAbsolutePath || curNode.absolutePath;
+                  if (fileAbsolutePath) {
+                    return fileAbsolutePath;
+                  }
+                }
+                return undefined;
+              },
             },
           },
           {

--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -1,3 +1,4 @@
+import { GatsbyNode } from 'gatsby';
 import path from 'path';
 import { defaults, isString } from 'lodash';
 import traverse from 'traverse';
@@ -12,13 +13,14 @@ import {
 export type GatsbyPluginArgs = {
   node: MarkdownNode;
   getNodesByType: (type: string) => GatsbyFile[];
+  getNode: (id: string) => GatsbyNode;
   reporter: {
     info: (msg: string, error?: Error) => void;
   };
 };
 
 export const onCreateNode = (
-  { node, getNodesByType }: GatsbyPluginArgs,
+  { node, getNodesByType, getNode }: GatsbyPluginArgs,
   pluginOptions: PluginOptions
 ) => {
   const options = defaults(pluginOptions, defaultPluginOptions);
@@ -26,7 +28,10 @@ export const onCreateNode = (
   if (node.internal.type === `MarkdownRemark` || node.internal.type === `Mdx`) {
     const files = getNodesByType(`File`);
 
-    const directory = path.dirname(node.fileAbsolutePath);
+    let fileAbsolutePath = node.fileAbsolutePath;
+    if (!fileAbsolutePath && pluginOptions.resolveNodePath) {
+    }
+    const directory = path.dirname(fileAbsolutePath);
 
     // Deeply iterate through frontmatter data for absolute paths
     traverse(node.frontmatter).forEach(function (value) {


### PR DESCRIPTION
in case you created markdown nodes programmatically 
(e.g. since you want to process markdown content in frontmatter fields), 
you can now provide a custom resolver function that calculates the correct path for the markdown content.

Fixes #43