### PR TITLE
Allow any v4 of lodash after 4.17.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "cheerio": "1.0.0-rc.3",
     "is-invalid-path": "1.0.2",
-    "lodash": "4.17.20",
+    "lodash": "^4.17.20",
     "traverse": "0.6.6",
     "unist-util-select": "3.0.1"
   },


### PR DESCRIPTION
Currently the package.json specifies the exact version of 4.17.20 for lodash, which means multiple copies end up in our bundle.