### PR TITLE
Ensure absolute path exists

### DIFF
--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -23,7 +23,7 @@ export const onCreateNode = (
 ) => {
   const options = defaults(pluginOptions, defaultPluginOptions);
 
-  if (node.internal.type === `MarkdownRemark` || node.internal.type === `Mdx`) {
+  if (node.fileAbsolutePath && node.internal.type === `MarkdownRemark` || node.internal.type === `Mdx`) {
     const files = getNodesByType(`File`);
 
     const directory = path.dirname(node.fileAbsolutePath);


### PR DESCRIPTION
Resolves #38

Contentful allows for a field type of "Long Text". This is created as a `MarkdownRemark` node. This node does **not** have a `fileAbsolutePath` set (i.e., is `null`). Invoking `path.dirname` without a value throws the error shown in #38.

![](https://p-1MFmr4.b2.n0.cdn.getcloudapp.com/items/7KuQjWEX/bb62c810-6b11-4767-806a-c111a65cd7b9.jpg?v=c92dd6b968109e9ac7b3bf949056efa4)

It appears as though the author was aware of nodes without this value populated existing, given the guard implemented here: https://github.com/danielmahon/gatsby-remark-relative-images/blob/3da59696cd3e0f8eb01f0376004a95d011d1f2e3/src/index.ts#L81-L83

This PR adds the same guard to the `onCreateNode` definition