### PR TITLE
Added persistent node update to relative image paths

### DIFF
--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -19,10 +19,11 @@ export type GatsbyPluginArgs = {
 };
 
 export const onCreateNode = (
-  { node, getNodesByType }: GatsbyPluginArgs,
+  { node, getNodesByType, actions }: GatsbyPluginArgs,
   pluginOptions: PluginOptions
 ) => {
   const options = defaults(pluginOptions, defaultPluginOptions);
+  const { createNodeField } = actions;
 
   if (node.fileAbsolutePath && node.internal.type === `MarkdownRemark` || node.internal.type === `Mdx`) {
     const files = getNodesByType(`File`);
@@ -56,6 +57,12 @@ export const onCreateNode = (
       const newValue = slash(path.relative(directory, file.absolutePath));
 
       this.update(newValue);
+      
+      createNodeField({
+        node,
+        name: `frontmatter`,
+        value: node.frontmatter,
+      });
     });
   }
 };

--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -16,6 +16,13 @@ export type GatsbyPluginArgs = {
   reporter: {
     info: (msg: string, error?: Error) => void;
   };
+  actions: {
+    createNodeField: (args: {
+      node: MarkdownNode;
+      name: string;
+      value: any;
+    }) => void;
+  };
 };
 
 export const onCreateNode = (
@@ -57,7 +64,7 @@ export const onCreateNode = (
       const newValue = slash(path.relative(directory, file.absolutePath));
 
       this.update(newValue);
-      
+
       createNodeField({
         node,
         name: `frontmatter`,


### PR DESCRIPTION
Current solution only works in development build, which already had been addressed in various issues. The cause for the common "null" instead of image comes from in-memory node processing which does not persist throughout Gatsby build pipeline.

#56
#61

https://github.com/danielmahon/gatsby-remark-relative-images/issues/61#issuecomment-1646669116

# Proof of working

## Before the change
![image](https://github.com/danielmahon/gatsby-remark-relative-images/assets/26150059/bfba30f7-a333-4b32-affe-b973486d44bf)

## After the change
![image](https://github.com/danielmahon/gatsby-remark-relative-images/assets/26150059/27795ae5-69ed-414c-94c7-cc76d466cfc0)

